### PR TITLE
fix(daemon): make pipe local in loop

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -32,7 +32,12 @@ func daemon(cmd *cobra.Command, args []string) {
 		schedule := config.GetString(fmt.Sprintf("pipes.%s.cron", pipe))
 		if schedule != "" {
 			log.Infof("Scheduling pipe:%s to run at: %s", pipe, schedule)
-			scheduler.AddFunc(schedule, func() { runPipe(pipe) })
+			pipe := pipe
+			_, err = scheduler.AddFunc(schedule, func() { runPipe(pipe) })
+			if err != nil {
+				log.Warnf("Failed to schedule pipe:%s: %v", pipe, err)
+				continue
+			}
 			found += 1
 		}
 	}


### PR DESCRIPTION
This fixes a bug where all scheduled actions executed the last pipe in the config, instead of the correct pipe.

This also catches syntax errors in the cron schedule string.

Sorry I didn't catch this earlier!