### PR TITLE
Add email template as an optional config

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ include-header = true
 include-footer = true
 #footer = Your custom footer
 #logo = internal:goeland.png
+#template = /path/to/template.html
 ```
 
 ## Examples

--- a/cmd/asset/config.default.toml
+++ b/cmd/asset/config.default.toml
@@ -37,6 +37,9 @@ password = "pass"
 ## Logo file
 #logo = internal:goeland.png
 
+## Template file
+#template = "/path/to/template.html"
+
 [sources]
 
 [sources.hackernews]

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,20 +31,33 @@ import (
 const logoAttachmentName = "logo.png"
 
 //go:embed asset/email.default.html
-var emailBytes []byte
+var defaultEmailBytes []byte
 
 //go:embed asset/goeland@250w.png
 var logoBytes []byte
 
-func createEmailTemplate(_ config.Provider) (*template.Template, error) {
+func createEmailTemplate(config config.Provider) (*template.Template, error) {
 	minifier := minify.New()
 	minifier.Add("text/html", &mhtml.Minifier{
 		KeepConditionalComments: true,
 	})
+
+	emailBytes := defaultEmailBytes
+
+	templateFilename := config.GetString("email.template")
+	if len(templateFilename) > 0 {
+		var err error
+		emailBytes, err = ioutil.ReadFile(templateFilename)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	minified, err := minifier.Bytes("text/html", emailBytes)
 	if err != nil {
 		return nil, err
 	}
+
 	tpl := template.Must(template.New("email").Parse(string(minified)))
 	return tpl, nil
 }


### PR DESCRIPTION
@slurdge first of all thank you for goeland, this is super cool.

In this PR I'd like to suggest the `email.template` config in `config.toml` so that users can specify the path to a template file to be used when composing the email. This will allow more control over the email/htmlfile style for users who need to go beyond the existing customization options.