### PR TITLE
fix: default to SSLTLS encryption when port is 465

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -90,6 +90,9 @@ func createEmailPool(config config.Provider) (*email.SMTPClient, error) {
 	encryption, found := encryptions[config.GetString("email.encryption")]
 	if !found {
 		encryption = email.EncryptionSTARTTLS
+		if port == 465 {
+			encryption = email.EncryptionSSLTLS
+		}
 	}
 	server.Encryption = encryption
 	if config.GetBool("email.allow-insecure") {


### PR DESCRIPTION
I spent an hour trying to understand why the SMTP connection would timeout. I just didn't expect the default encryption to be STARTTLS. Figured it out by looking at the code.
I propose this PR to be a little bit smarter about which encryption to default to.