### PR TITLE
feat: get config from standard places

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,9 @@ func ReadDefaultConfig(appName string, configName string) {
 	viper.SetDefault("run-at-startup", false)
 
 	viper.SetConfigFile(configName)
+	viper.AddConfigPath("/etc/goeland")
 	viper.AddConfigPath("$HOME/.goeland")
+	viper.AddConfigPath("$XDG_CONFIG_HOME/goeland")
 	viper.AddConfigPath(".")
 	if ex, err := os.Executable(); err == nil {
 		exPath := filepath.Dir(ex)


### PR DESCRIPTION
I think the creation of the config file should also be in those directories: `$XDG_CONFIG_HOME/goeland/config.toml` and if does not exist `/etc/goeland/config.toml`.
The database should also probably go in `$XDG_STATE_HOME/goeland/goeland.db` or `/var/lib/goeland/goeland.db`.

And to support macOS and windows as much, something like https://github.com/adrg/xdg could be used.