### PR TITLE
feat: add password_file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ If you are interested in another platform supported, please open a PR or submit 
 ## Usage
 
 On first run, if it doesn't exist yet, goeland will create a `config.toml` with the default values. You need to adjust the `[email]` section with your SMTP server details.
+The config values can also be set with environment variables (e.g. `GOELAND_EMAIL_PASSWORD_FILE=/path/to/pass`).
 
 ### Sources
 
@@ -172,6 +173,7 @@ host = "smtp.example.com"
 port = 25
 username = "default"
 password = "p4ssw0rd"
+# password_file = /run/password/goeland_smtp_pass
 encryption = "tls"
 allow-insecure = false
 authentication = "plain"

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -74,6 +74,17 @@ func createEmailPool(config config.Provider) (*email.SMTPClient, error) {
 	}
 	user := config.GetString("email.username")
 	pass := config.GetString("email.password")
+	passFile := config.GetString("email.password_file")
+	if len(passFile) > 0 {
+		if len(pass) > 0 {
+			log.Warn("Both password and password_file are set. Using password_file.")
+		}
+		passFileContent, err := ioutil.ReadFile(passFile)
+		if err != nil {
+			return nil, fmt.Errorf("error while reading password file: %v", err)
+		}
+		pass = string(passFileContent)
+	}
 	//auth := smtp.PlainAuth("", user, pass, host)
 	server := email.NewSMTPClient()
 	authentications := map[string]email.AuthType{"none": email.AuthNone, "plain": email.AuthPlain, "login": email.AuthLogin, "crammd5": email.AuthCRAMMD5}

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+	"strings"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -35,6 +36,8 @@ type Provider interface {
 // ReadDefaultConfig reads the configuration file
 func ReadDefaultConfig(appName string, configName string) {
 	viper.SetEnvPrefix(appName)
+    replacer := strings.NewReplacer(".", "_")
+    viper.SetEnvKeyReplacer(replacer)
 	viper.AutomaticEnv()
 
 	// global defaults


### PR DESCRIPTION
It's becoming pretty standard to be able to set secrets with an environment variable finishing with `_FILE`. Unfortunately, viper does not do it by default: https://github.com/spf13/viper/issues/1022.

The `viper.SetEnvKeyReplacer(replacer)` line is taken from https://github.com/spf13/viper/issues/239#issuecomment-248318912.

I'm currently in the process of packaging goeland for NixOS, this will make things simpler and more secure.