### PR TITLE
fix: default encryption set twice

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,6 @@ func ReadDefaultConfig(appName string, configName string) {
 	viper.SetDefault("email.timeout-ms", 5000)
 	viper.SetDefault("email.include-header", true)
 	viper.SetDefault("email.include-footer", true)
-	viper.SetDefault("email.encryption", "tls")
 	viper.SetDefault("email.allow-insecure", false)
 	viper.SetDefault("email.authentication", "plain")
 	viper.SetDefault("run-at-startup", false)


### PR DESCRIPTION
I thought I had tested https://github.com/slurdge/goeland/commit/fa44112602c0962a2a5e65d05c60f43c97bc5b26 but apparently I didn't because I hadn't removed the default set in `config/config.go`.
It's not useful to set a default there as we are setting one in `cmd/run.go` with a bit more logic to it.