### PR TITLE
fix: do not include source with no entries in ToC

### DIFF
--- a/internal/goeland/filters/filter.go
+++ b/internal/goeland/filters/filter.go
@@ -252,6 +252,9 @@ func filterEmbedImage(source *goeland.Source, params *filterParams) {
 }
 
 func filterToc(source *goeland.Source, params *filterParams) {
+	if len(source.Entries) == 0 {
+		return
+	}
 	toc := goeland.Entry{}
 	args := params.args
 	if len(args) > 0 && strings.ToLower(args[0]) == "title" {


### PR DESCRIPTION
Just a little fix. It's weird to have an empty list in the ToC.