### PR TITLE
Feature: Add includesourcetitle filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The available filters are as follows:
 in your config file.
 
 * includelink: Include the link of entries in the digest form
+* includesourcetitle: Include source titles of entries in the digest form
 * retrieve: Retrieves the full content from a goquery. E.g. you can use `retrieve(div.content)` to get the full excerpts of Next INpact's [LeBrief](https://www.nextinpact.com/lebrief/)
 * language: Keep only the specified languages (best effort detection), use like this: `language(en,de)`
 * untrack: Removes feedburner pixel tracking

--- a/internal/goeland/fetch/feed.go
+++ b/internal/goeland/fetch/feed.go
@@ -123,7 +123,7 @@ func fetchFeed(source *goeland.Source, feedLocation string, isFile bool, allowIn
 			hash.Write([]byte(entry.URL))
 			entry.UID = hex.EncodeToString(hash.Sum([]byte{}))
 		}
-		entry.Source = *source
+		entry.Source = source
 		source.Entries = append(source.Entries, entry)
 	}
 	return nil

--- a/internal/goeland/fetch/feed.go
+++ b/internal/goeland/fetch/feed.go
@@ -56,6 +56,10 @@ func fetchFeed(source *goeland.Source, feedLocation string, isFile bool, allowIn
 			return fmt.Errorf("cannot open or parse url: %s (%v)", feedLocation, err)
 		}
 	}
+
+	source.Title = feed.Title
+	source.URL = feed.Link
+
 	for _, item := range feed.Items {
 
 		entry := goeland.Entry{}
@@ -119,10 +123,9 @@ func fetchFeed(source *goeland.Source, feedLocation string, isFile bool, allowIn
 			hash.Write([]byte(entry.URL))
 			entry.UID = hex.EncodeToString(hash.Sum([]byte{}))
 		}
+		entry.Source = *source
 		source.Entries = append(source.Entries, entry)
 	}
-	source.Title = feed.Title
-	source.URL = feed.Link
 	return nil
 }
 

--- a/internal/goeland/filters/filter.go
+++ b/internal/goeland/filters/filter.go
@@ -159,7 +159,6 @@ func filterDigestGeneric(source *goeland.Source, level int, useFirstEntryTitle b
 	content := ""
 	for _, entry := range source.Entries {
 		if entry.IncludeSourceTitle && previousSource != entry.Source  {
-			content += "<hr/>"
 			content += fmt.Sprintf(`<h%d><a href="%s">%s</a></h%d>`, level - 1, entry.Source.URL, entry.Source.Title, level - 1)
 			previousSource = entry.Source
 		}

--- a/internal/goeland/filters/filter.go
+++ b/internal/goeland/filters/filter.go
@@ -50,6 +50,7 @@ var filters = map[string]filter{
 		to="Another string"
 	  in your config file.`, filterReplace},
 	"includelink": {"Include the link of entries in the digest form", filterIncludeLink},
+	"includesourcetitle": {"Include source titles of the entries in the digest form. Useful for merge sources", filterIncludeSourceTitle},
 	"language":    {"Keep only the specified languages (best effort detection), use like this: language(en,de)", filterLanguage},
 	"unseen":      {"Keep only unseen entry", filterUnSeen},
 	"lebrief":     {"Deprecated. Use retrieve(div.content) instead. Retrieves the full excerpts for Next INpact's Lebrief", filterLeBrief},
@@ -154,8 +155,14 @@ func filterDigestGeneric(source *goeland.Source, level int, useFirstEntryTitle b
 	if useFirstEntryTitle && len(source.Entries) > 0 {
 		digest.Title = source.Entries[0].Title
 	}
+	previousSourceTitle := ""
 	content := ""
 	for _, entry := range source.Entries {
+		if entry.IncludeSourceTitle && previousSourceTitle != entry.Source.Title  {
+			content += "<hr/>"
+			content += fmt.Sprintf(`<h%d><a href="%s">%s</a></h%d>`, level - 1, entry.Source.URL, entry.Source.Title, level - 1)
+			previousSourceTitle = entry.Source.Title
+		}
 		if entry.IncludeLink {
 			content += fmt.Sprintf(`<h%d><a href="%s">%s</a></h%d>`, level, entry.URL, entry.Title, level)
 		} else {
@@ -221,6 +228,12 @@ func filterSanitize(source *goeland.Source, params *filterParams) {
 func filterIncludeLink(source *goeland.Source, params *filterParams) {
 	for i := range source.Entries {
 		source.Entries[i].IncludeLink = true
+	}
+}
+
+func filterIncludeSourceTitle(source *goeland.Source, params *filterParams) {
+	for i := range source.Entries {
+		source.Entries[i].IncludeSourceTitle = true
 	}
 }
 

--- a/internal/goeland/filters/filter.go
+++ b/internal/goeland/filters/filter.go
@@ -155,13 +155,13 @@ func filterDigestGeneric(source *goeland.Source, level int, useFirstEntryTitle b
 	if useFirstEntryTitle && len(source.Entries) > 0 {
 		digest.Title = source.Entries[0].Title
 	}
-	previousSourceTitle := ""
+	var previousSource *goeland.Source
 	content := ""
 	for _, entry := range source.Entries {
-		if entry.IncludeSourceTitle && previousSourceTitle != entry.Source.Title  {
+		if entry.IncludeSourceTitle && previousSource != entry.Source  {
 			content += "<hr/>"
 			content += fmt.Sprintf(`<h%d><a href="%s">%s</a></h%d>`, level - 1, entry.Source.URL, entry.Source.Title, level - 1)
-			previousSourceTitle = entry.Source.Title
+			previousSource = entry.Source
 		}
 		if entry.IncludeLink {
 			content += fmt.Sprintf(`<h%d><a href="%s">%s</a></h%d>`, level, entry.URL, entry.Title, level)

--- a/internal/goeland/source.go
+++ b/internal/goeland/source.go
@@ -6,13 +6,15 @@ import (
 
 // Entry This represent an entry produced by a source
 type Entry struct {
-	UID         string
-	Title       string
-	Content     string
-	URL         string
-	Date        time.Time
-	IncludeLink bool
-	ImageURL    string
+	UID                string
+	Title              string
+	Content            string
+	URL                string
+	Date               time.Time
+	IncludeLink        bool
+	IncludeSourceTitle bool
+	ImageURL           string
+	Source             Source
 }
 
 // Source ...

--- a/internal/goeland/source.go
+++ b/internal/goeland/source.go
@@ -14,7 +14,7 @@ type Entry struct {
 	IncludeLink        bool
 	IncludeSourceTitle bool
 	ImageURL           string
-	Source             Source
+	Source             *Source
 }
 
 // Source ...


### PR DESCRIPTION
This PR adds a new filter which, when enabled it will display the source title above of each group of merged entries.
This will make it easier to know from which source the entry is coming from.

Example:

```toml
[sources]

[sources.slurdge]
type = "feed"
url = "https://nitter.smnz.de/slurdge/rss"
filters = ["first(1)", "includelink", "includesourcetitle"]

[sources.hackernews]
type = "feed"
url = "https://hnrss.org/newest"
filters = ["first(1)", "includelink", "includesourcetitle"]

[sources.codinghumor]
type = "feed"
url = "https://nitter.smnz.de/search/rss?f=tweets&q=%23CodingHumor&f-images=on&e-nativeretweets=on"
filters = ["first(1)", "includelink", "includesourcetitle"]

[sources.daily_digest]
type = "merge"
sources = ["slurdge", "hackernews", "codinghumor"]
filters = ["digest(3)"]

[pipes]

[pipes.daily_digest]
source = "daily_digest"
destination = "email"
email_to = ""
email_from = "l"
email_title = "🧪 Test Digest"
```

![image](https://user-images.githubusercontent.com/645895/227716050-d316308c-48f4-409e-a776-81cff2f68c5f.png)

Before (without the `includesourcetitle` filter):

![image](https://user-images.githubusercontent.com/645895/227716118-8ce9ce82-6c90-49ac-bf9e-38c0dff1d383.png)
