### PR TITLE
Added EntryURL variable to be available in email template

### DIFF
--- a/cmd/asset/email.default.html
+++ b/cmd/asset/email.default.html
@@ -40,7 +40,7 @@
             <!-- The h1 is the main heading of the document and should come first. -->
             <!-- We can override the default styles inline. -->
             <h1 style="font-size: 32px; font-weight: 800; line-height: 32px; margin: 48px 0; text-align: center; ">
-                <a href="{{.EntryURL}}">{{.EntryTitle}}</a>
+                {{.EntryTitle}}
             </h1>
             {{end}}
         </header>

--- a/cmd/asset/email.default.html
+++ b/cmd/asset/email.default.html
@@ -40,7 +40,7 @@
             <!-- The h1 is the main heading of the document and should come first. -->
             <!-- We can override the default styles inline. -->
             <h1 style="font-size: 32px; font-weight: 800; line-height: 32px; margin: 48px 0; text-align: center; ">
-                {{.EntryTitle}}
+                <a href="{{.EntryURL}}">{{.EntryTitle}}</a>
             </h1>
             {{end}}
         </header>

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -154,6 +154,7 @@ func formatHTMLEmail(entry *goeland.Entry, config config.Provider, tpl *template
 	data := struct {
 		EntryTitle    string
 		EntryContent  string
+		EntryURL      string
 		IncludeHeader bool
 		IncludeTitle  bool
 		IncludeFooter bool
@@ -163,6 +164,7 @@ func formatHTMLEmail(entry *goeland.Entry, config config.Provider, tpl *template
 	}{
 		EntryTitle:    html.EscapeString(entry.Title),
 		EntryContent:  entry.Content,
+		EntryURL:      entry.URL,
 		IncludeHeader: config.GetBool("email.include-header"),
 		IncludeTitle:  config.GetBool("email.include-title"),
 		IncludeFooter: config.GetBool("email.include-footer"),

--- a/documentation/templates.md
+++ b/documentation/templates.md
@@ -10,6 +10,7 @@ The following variables can be used inside the template:
 |--------|-----|
 |EntryTitle| The title of the entry. If you have a digest, it will be "Digest for" |
 |EntryContent | The main body of the entry |
+|EntryURL | The URL of the entry |
 |IncludeHeader | Include the header logo |
 |IncludeTitle | Include the header title |
 |IncludeFooter| Include the footer (which can be overridden by config)|


### PR DESCRIPTION
Added a variable called EntryURL which can be used in an email template to link back to the original item in case a reader wants to visit the originating site.