### PR TITLE
Set base URL in default template to support relative links

### DIFF
--- a/cmd/asset/email.default.html
+++ b/cmd/asset/email.default.html
@@ -15,6 +15,7 @@
     <style type="text/css">
         {{.CSS}}
     </style>
+    <base href="{{.EntryURL}}">
 </head>
 
 <body>


### PR DESCRIPTION
Tested with this feed: https://swordscomic.com/comic/feed/